### PR TITLE
Add basic prototype with quiz and odù cards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,190 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Ìṣẹ̀ṣe L’agbà — Odù</title>
+<style>
+  :root{ color-scheme:dark; --bg:#0b0f14; --card:#121826; --text:#e7eef7; --accent:#68d391; --muted:#9fb3c8; --radius:14px; }
+  body{ margin:0; background:var(--bg); color:var(--text); font-family:system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+  .wrap{ max-width:920px; margin:0 auto; padding:24px; }
+  .card{ background:var(--card); border-radius:var(--radius); padding:18px 20px; box-shadow:0 6px 24px rgba(0,0,0,.25); }
+  .grid{ display:grid; gap:16px; }
+  .btn{ display:inline-block; padding:12px 16px; border-radius:12px; border:1px solid #243046; color:var(--text); text-decoration:none; cursor:pointer }
+  .btn.primary{ background:var(--accent); color:#0b0f14; border:none; font-weight:600 }
+  .pill{ display:inline-block; padding:6px 10px; border-radius:999px; background:#0f1422; color:var(--muted); font-size:12px }
+  .options{ display:grid; gap:10px; margin-top:12px }
+  .option{ padding:12px 14px; border-radius:12px; border:1px solid #2a3854; cursor:pointer }
+  .option:hover{ border-color:#3b82f6 }
+  .title{ margin:0 0 8px 0 }
+  .muted{ color:var(--muted) }
+</style>
+</head>
+<body>
+<div class="wrap grid">
+  <header class="grid card">
+    <h1 class="title">Ìṣẹ̀ṣe L’agbà — Odù</h1>
+    <p class="muted">Ferramenta educativa. Não substitui consulta tradicional.</p>
+    <div class="grid" style="grid-template-columns:repeat(auto-fit,minmax(240px,1fr))">
+      <a class="btn" id="btn-explorar">Explorar odù</a>
+      <a class="btn primary" id="btn-quiz">Consultar meu odù (quiz)</a>
+      <a class="btn" id="btn-dia">Odù do dia</a>
+    </div>
+  </header>
+
+  <section class="card" id="stage"></section>
+</div>
+
+<script>
+// ====== Dados de demonstração (trocar por base completa) ======
+const ODUS = [
+  { id:"1-1", slug:"ejio gbe", nome:"Èjìogbè", temas:["origem","clareza"], conselhos:["Organize o básico.","Busque lucidez antes da pressa."]},
+  { id:"2-1", slug:"oyeku meji", nome:"Òyèkú Méjì", temas:["profundidade","transformação"], conselhos:["Respeite seus limites.","Transforme silêncio em insight."]},
+  { id:"3-2", slug:"iwori meji", nome:"Ìwòrì Méjì", temas:["movimento","ajuste"], conselhos:["Revise rotas.","Adapte-se sem perder princípios."]}
+];
+
+// ====== Perguntas (exemplo) ======
+const PERGUNTAS = [
+  {
+    id: "inicio",
+    enunciado: "Diante de um novo começo, você tende a:",
+    opcoes: [
+      { label: "Começar logo e aprender fazendo", pontos: { "1-1": 2, "3-2": 1 } },
+      { label: "Refletir profundamente antes de agir", pontos: { "2-1": 2 } },
+      { label: "Testar caminhos e ajustar na marcha", pontos: { "3-2": 2 } }
+    ]
+  },
+  {
+    id: "obstaculo",
+    enunciado: "Quando surge um obstáculo, sua primeira resposta é:",
+    opcoes: [
+      { label: "Traçar um plano estruturado", pontos: { "1-1": 2 } },
+      { label: "Recolher-se para recuperar energia", pontos: { "2-1": 2 } },
+      { label: "Mudar de tática rapidamente", pontos: { "3-2": 2, "1-1": 1 } }
+    ]
+  }
+];
+
+// ====== Infra UI ======
+const stage = document.getElementById('stage');
+function show(html){ stage.innerHTML = html; }
+function btn(label, onclick, cls='btn'){ return `<a class="${cls}" onclick="${onclick}">${label}</a>` }
+
+// ====== Telas ======
+function telaExplorar(){
+  const items = ODUS.map(o => `
+    <div class="card">
+      <div class="pill">${o.id}</div>
+      <h3 style="margin:.4rem 0">${o.nome}</h3>
+      <div class="muted">Temas: ${o.temas.join(", ")}</div>
+      <div style="margin-top:10px">${btn("Ver", `verOdu('${o.id}')`, "btn primary")}</div>
+    </div>
+  `).join("");
+  show(`<h2 class="title">Explorar odù</h2>
+        <div class="grid" style="grid-template-columns:repeat(auto-fit,minmax(220px,1fr))">${items}</div>`);
+}
+window.verOdu = function(id){
+  const o = ODUS.find(x=>x.id===id);
+  show(`
+    <div class="grid">
+      <div><a class="btn" onclick="telaExplorar()">← Voltar</a></div>
+      <div class="card">
+        <div class="pill">${o.id}</div>
+        <h2 class="title">${o.nome}</h2>
+        <p class="muted">Temas: ${o.temas.join(", ")}</p>
+        <h3>Conselhos</h3>
+        <ul>${o.conselhos.map(c=>`<li>${c}</li>`).join("")}</ul>
+      </div>
+    </div>
+  `);
+};
+
+function telaQuiz(i=0, score={}){
+  if(i >= PERGUNTAS.length){
+    return telaResultado(score);
+  }
+  const q = PERGUNTAS[i];
+  const ops = q.opcoes.map((op,idx)=>`
+    <div class="option" onclick="responder(${i},${idx})">${op.label}</div>
+  `).join("");
+  show(`
+    <div class="grid">
+      <div class="muted">Pergunta ${i+1} de ${PERGUNTAS.length}</div>
+      <h2 class="title">${q.enunciado}</h2>
+      <div class="options">${ops}</div>
+      <div style="margin-top:14px"><a class="btn" onclick="telaHome()">Cancelar</a></div>
+    </div>
+  `);
+  window._state = { i, score };
+}
+window.responder = function(i, idx){
+  const q = PERGUNTAS[i];
+  const pontos = q.opcoes[idx].pontos;
+  const score = { ...window._state.score };
+  Object.entries(pontos).forEach(([odu, val])=>{
+    score[odu] = (score[odu]||0) + val;
+  });
+  telaQuiz(i+1, score);
+};
+
+function telaResultado(score){
+  const ranking = Object.entries(score).sort((a,b)=>b[1]-a[1]);
+  const [principalId] = ranking[0] || [ODUS[0].id];
+  const [apoio1Id, apoio2Id] = (ranking.slice(1,3).map(x=>x[0]));
+  const principal = ODUS.find(o=>o.id===principalId) || ODUS[0];
+  const apoio1 = ODUS.find(o=>o.id===apoio1Id);
+  const apoio2 = ODUS.find(o=>o.id===apoio2Id);
+
+  const apoioCards = [apoio1, apoio2].filter(Boolean).map(o=>`
+    <div class="card"><div class="pill">${o.id}</div><strong>${o.nome}</strong><div class="muted">${o.temas.join(", ")}</div></div>
+  `).join("");
+
+  show(`
+    <div class="grid">
+      <div class="card">
+        <h2 class="title">Seu odù (perfil do momento)</h2>
+        <div class="pill">${principal.id}</div>
+        <h3 style="margin:.4rem 0">${principal.nome}</h3>
+        <p class="muted">Temas: ${principal.temas.join(", ")}</p>
+        <h4>Conselhos</h4>
+        <ul>${principal.conselhos.map(c=>`<li>${c}</li>`).join("")}</ul>
+        <div style="margin-top:12px">
+          ${btn("Ver detalhes", `verOdu('${principal.id}')`, "btn primary")}
+          ${btn("Refazer", "telaQuiz(0,{})")}
+        </div>
+      </div>
+      ${apoioCards ? `<div class="grid" style="grid-template-columns:repeat(auto-fit,minmax(240px,1fr))">${apoioCards}</div>` : ""}
+    </div>
+  `);
+}
+
+// “Odù do dia” com semente
+function telaOduDoDia(){
+  // Exemplo simples: usa data + “aleatório” do navegador
+  const seed = Date.now() ^ Math.floor(Math.random()*1e9);
+  const idx = seed % ODUS.length; // troque por cálculo (grupo,combinação) dentro do seu conjunto 252/256
+  const o = ODUS[idx];
+  show(`
+    <div class="card">
+      <h2 class="title">Odù do dia (inspiração)</h2>
+      <div class="pill">${o.id}</div>
+      <h3 style="margin:.4rem 0">${o.nome}</h3>
+      <p class="muted">Reflexão: ${o.temas.join(", ")}</p>
+      <h4>Sugestões</h4>
+      <ul>${o.conselhos.map(c=>`<li>${c}</li>`).join("")}</ul>
+      <div style="margin-top:12px">${btn("Explorar detalhes", `verOdu('${o.id}')`, "btn")}</div>
+    </div>
+  `);
+}
+
+// Navegação básica
+function telaHome(){
+  show(`<p>Escolha uma opção acima para começar.</p>`);
+}
+document.getElementById('btn-explorar').onclick = telaExplorar;
+document.getElementById('btn-quiz').onclick = ()=>telaQuiz(0,{});
+document.getElementById('btn-dia').onclick = telaOduDoDia;
+telaHome();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add initial HTML prototype with navigation to explore odù, take a quiz and view an "odù do dia"
- include sample odù data and question mapping for demonstration

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fc381ae248321aa968c357b0a3a21